### PR TITLE
Use 'paramtype = "light"' instead of deprecated 'light_propagates'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -479,10 +479,10 @@ minetest.register_node("walking_light:clear", {
 	tiles = {"walking_light.png"},
 	-- tiles = {"walking_light_debug.png"},
 	--inventory_image = minetest.inventorycube("walking_light.png"),
-	--paramtype = "light",
+	paramtype = "light",
 	walkable = false,
 	--is_ground_content = true,
-	light_propagates = true,
+	--light_propagates = true,
 	sunlight_propagates = true,
 	--light_source = 13,
 	selection_box = {
@@ -499,7 +499,7 @@ minetest.register_node("walking_light:light", {
 	paramtype = "light",
 	walkable = false,
 	is_ground_content = true,
-	light_propagates = true,
+	--light_propagates = true,
 	sunlight_propagates = true,
 	light_source = 13,
 	selection_box = {


### PR DESCRIPTION
I am not 100% sure that I did this right.