### PR TITLE
Any light to any mese tool

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,0 +1,1 @@
+default

--- a/init.lua
+++ b/init.lua
@@ -17,7 +17,7 @@ walking_light = {}
 
 -- list of items that use walking light
 local light_items = {
-	"default:torch", "walking_light:pick_mese",
+	"default:torch",
 	"walking_light:helmet_diamond", "walking_light:megatorch"
 }
 
@@ -542,20 +542,7 @@ function update_walking_light_node()
 end
 update_walking_light_node()
 
-minetest.register_tool("walking_light:pick_mese", {
-	description = "Mese Pickaxe with light",
-	inventory_image = "walking_light_mesepick.png",
-	wield_image = "default_tool_mesepick.png",
-	tool_capabilities = {
-		full_punch_interval = 1.0,
-		max_drop_level=3,
-		groupcaps={
-			cracky={times={[1]=2.0, [2]=1.0, [3]=0.5}, uses=20, maxlevel=3},
-			crumbly={times={[1]=2.0, [2]=1.0, [3]=0.5}, uses=20, maxlevel=3},
-			snappy={times={[1]=2.0, [2]=1.0, [3]=0.5}, uses=20, maxlevel=3}
-		}
-	},
-})
+walking_light.register_tool('pick')
 
 minetest.register_tool("walking_light:helmet_diamond", {
 	description = "Diamond Helmet with light",
@@ -614,14 +601,6 @@ minetest.register_node("walking_light:megatorch", {
     groups = {choppy=2,dig_immediate=3,flammable=1,attached_node=1},
     legacy_wallmounted = true,
     --sounds = default.node_sound_defaults(),
-})
-
-minetest.register_craft({
-	output = 'walking_light:pick_mese',
-	recipe = {
-		{'default:torch'},
-		{'default:pick_mese'},
-	}
 })
 
 minetest.register_craft({

--- a/init.lua
+++ b/init.lua
@@ -36,6 +36,25 @@ function walking_light.getLightItems()
 	return light_items
 end
 
+function walking_light.register_tool(tool)
+	item = 'walking_light:' .. tool .. '_mese'
+	default = 'default:' .. tool .. '_mese'
+
+	definition = table.copy(minetest.registered_items[default])
+	definition.description = definition.description .. ' with light'
+	definition.inventory_image = 'walking_light_mese' .. tool .. '.png'
+
+	minetest.register_tool(item, definition)
+	minetest.register_craft({
+		output = item,
+		recipe = {
+			{'default:torch'},
+			{ default },
+		}
+	})
+
+	walking_light.addLightItem(item)
+end
 
 -- from http://lua-users.org/wiki/IteratorsTutorial
 -- useful for removing things from a table because removing from the middle makes it skip elements otherwise


### PR DESCRIPTION
I haven't actually added any other tools e.g. axe, shovel, sword because I'm not sure how to edit the graphics.

add public function to add light to any mese tool

* depends on default to get basic tool definitions
* public so can be used by tool-adding mods

replace pick definition

* NB. this removes the OP crumbly,snappy properties
* benefit is it'll inherit any customised default:pick definition